### PR TITLE
feat: support semver aware exclusions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,10 +92,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
+name = "cranelift-bitset"
+version = "0.110.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=9bdb731ab653a3845a1fa6cb6fcb20505c049ee8#9bdb731ab653a3845a1fa6cb6fcb20505c049ee8"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "cranelift-entity"
-version = "0.109.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8cfdc315e5d18997093e040a8d234bea1ac1e118a716d3e30f40d449e78207b"
+version = "0.110.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=9bdb731ab653a3845a1fa6cb6fcb20505c049ee8#9bdb731ab653a3845a1fa6cb6fcb20505c049ee8"
 dependencies = [
  "serde",
  "serde_derive",
@@ -334,6 +342,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde"
@@ -562,23 +573,23 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d2912c53d9054984b380dfbd7579f9c3681b2a73b903a56bd71a1c4f175f1e"
+version = "23.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=9bdb731ab653a3845a1fa6cb6fcb20505c049ee8#9bdb731ab653a3845a1fa6cb6fcb20505c049ee8"
 
 [[package]]
 name = "wasmtime-environ"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f444e900e848b884d8a8a2949b6f5b92af642a3e663ff8fbe78731143a55be61"
+version = "23.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=9bdb731ab653a3845a1fa6cb6fcb20505c049ee8#9bdb731ab653a3845a1fa6cb6fcb20505c049ee8"
 dependencies = [
  "anyhow",
+ "cranelift-bitset",
  "cranelift-entity",
  "gimli",
  "indexmap",
  "log",
  "object",
  "postcard",
+ "semver",
  "serde",
  "serde_derive",
  "target-lexicon",
@@ -591,10 +602,10 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "22.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "412463e9000e14cf6856be48628d2213c20c153e29ffc22b036980c892ea6964"
+version = "23.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?rev=9bdb731ab653a3845a1fa6cb6fcb20505c049ee8#9bdb731ab653a3845a1fa6cb6fcb20505c049ee8"
 dependencies = [
+ "anyhow",
  "cranelift-entity",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,12 +211,11 @@ dependencies = [
  "anyhow",
  "base64",
  "heck 0.5.0",
- "wasm-encoder 0.209.1",
- "wasmparser",
+ "wasm-encoder 0.212.0",
+ "wasmparser 0.212.0",
  "wasmtime-environ",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser",
 ]
 
 [[package]]
@@ -287,6 +286,16 @@ dependencies = [
  "cobs",
  "embedded-io",
  "serde",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.68",
 ]
 
 [[package]]
@@ -454,6 +463,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1fc403891a21bcfb7c37834ba66a547a8f402146eba7265b5a6d88059c9ff2f"
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,13 +532,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501940df4418b8929eb6d52f1aade1fdd15a5b86c92453cb696e3c906bd3fc33"
 dependencies = [
  "leb128",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.209.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d32029ce424f6d3c2b39b4419fb45a0e2d84fb0751e0c0a32b7ce8bd5d97f46"
+checksum = "8a1849fac257fd76c43268555e73d74848c8dff23975c238c2cbad61cffe5045"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -528,8 +547,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.209.1",
- "wasmparser",
+ "wasm-encoder 0.212.0",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]
@@ -537,10 +556,10 @@ name = "wasm-tools-js"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "wasm-encoder 0.209.1",
+ "wasm-encoder 0.212.0",
  "wasm-metadata",
- "wasmparser",
- "wasmprinter",
+ "wasmparser 0.212.0",
+ "wasmprinter 0.212.0",
  "wat",
  "wit-bindgen",
  "wit-component",
@@ -562,13 +581,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmparser"
+version = "0.212.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d28bc49ba1e5c5b61ffa7a2eace10820443c4b7d1c0b144109261d14570fdf8"
+dependencies = [
+ "ahash",
+ "bitflags 2.6.0",
+ "hashbrown",
+ "indexmap",
+ "semver",
+ "serde",
+]
+
+[[package]]
 name = "wasmprinter"
 version = "0.209.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
 dependencies = [
  "anyhow",
- "wasmparser",
+ "wasmparser 0.209.1",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.212.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfac65326cc561112af88c3028f6dfdb140acff67ede33a8e86be2dc6b8956f7"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]
@@ -594,8 +638,8 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "wasm-encoder 0.209.1",
- "wasmparser",
- "wasmprinter",
+ "wasmparser 0.209.1",
+ "wasmprinter 0.209.1",
  "wasmtime-component-util",
  "wasmtime-types",
 ]
@@ -610,7 +654,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser",
+ "wasmparser 0.209.1",
 ]
 
 [[package]]
@@ -652,16 +696,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "wit-bindgen"
-version = "0.26.0"
+name = "windows-sys"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84376ff4f74ed07674a1157c0bd19e6627ab01fc90952a27ccefb52a24530f0"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88ba073cf16d5372720ec942a8ccbf61626074c6d4dd2e745299726ce8b89670"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec47e5bfd1bff0eeaf6d8b485cc1074891a197ab4225d504cb7a1ab88b02bf0"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabce76bbb8938536c437da0c3e1d4dda9065453f72a68f797c0cb3d67356a28"
 dependencies = [
  "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
@@ -669,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36d4706efb67fadfbbde77955b299b111dd096e6776d8c6561d92f6147941880"
+checksum = "1b43fbdd3497c471bbfb6973b1fb9ffe6949f158248cb43171d6f1cf3de7eaa3"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -680,22 +806,24 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c7526379ace8709ee9ab9f2bb50f112d95581063a59ef3097d9c10153886c9"
+checksum = "75956ff0a04a87ca0526b07199ce3b9baee899f2e4723b5b63aa296ab172ec52"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514295193d1a2f42e6a948cd7d9fd81e2b8fadc319667dcf19fd7aceaf2113a2"
+checksum = "bf509c4ef97b18ec0218741c8318706ac30ff16bc1731f990319a42bbbcfe8e3"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap",
+ "prettyplease",
+ "syn 2.0.68",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -703,11 +831,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0409a3356ca02599aff78f717968fd7f12df4bf879f325e2a97b45c84c90fff"
+checksum = "88d6f2e025e38395d71fc1bf064e581b2ad275ce322d6f8d87ddc5e76a7b8c42"
 dependencies = [
  "anyhow",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn 2.0.68",
@@ -717,9 +846,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.209.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a2bb5b039f9cb03425e1d5a6e54b441ca4ca1b1d4fa6a0924db67a55168f99"
+checksum = "8ed5b0f9fc3d6424787d2a49e1142bf954ae4f26ee891992c144f0cfd68c4b7f"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -728,18 +857,18 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.209.1",
+ "wasm-encoder 0.212.0",
  "wasm-metadata",
- "wasmparser",
+ "wasmparser 0.212.0",
  "wat",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-parser"
-version = "0.209.1"
+version = "0.212.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e79b9e3c0b6bb589dec46317e645851e0db2734c44e2be5e251b03ff4a51269"
+checksum = "ceeb0424aa8679f3fcf2d6e3cfa381f3d6fa6179976a2c05a6249dd2bb426716"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -750,7 +879,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser",
+ "wasmparser 0.212.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,7 +563,7 @@ dependencies = [
  "wat",
  "wit-bindgen",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.209.1",
 ]
 
 [[package]]
@@ -578,6 +578,18 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.209.1"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=10d2e21b2171cf2a2227f9de04ac89985042a5f0#10d2e21b2171cf2a2227f9de04ac89985042a5f0"
+dependencies = [
+ "ahash",
+ "bitflags 2.6.0",
+ "hashbrown",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -601,7 +613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ceca8ae6eaa8c7c87b33c25c53bdf299f8c2a764aee1179402ff7652ef3a6859"
 dependencies = [
  "anyhow",
- "wasmparser 0.209.1",
+ "wasmparser 0.209.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -638,7 +650,7 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "wasm-encoder 0.209.1",
- "wasmparser 0.209.1",
+ "wasmparser 0.209.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasmprinter 0.209.1",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -654,7 +666,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "wasmparser 0.209.1",
+ "wasmparser 0.209.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -801,7 +813,7 @@ checksum = "1b43fbdd3497c471bbfb6973b1fb9ffe6949f158248cb43171d6f1cf3de7eaa3"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.212.0",
 ]
 
 [[package]]
@@ -861,7 +873,24 @@ dependencies = [
  "wasm-metadata",
  "wasmparser 0.212.0",
  "wat",
- "wit-parser",
+ "wit-parser 0.212.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.209.1"
+source = "git+https://github.com/bytecodealliance/wasm-tools?rev=10d2e21b2171cf2a2227f9de04ac89985042a5f0#10d2e21b2171cf2a2227f9de04ac89985042a5f0"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.209.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=10d2e21b2171cf2a2227f9de04ac89985042a5f0)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,17 +39,17 @@ base64 = "0.22.1"
 heck =  "0.5.0"
 js-component-bindgen = { path = "./crates/js-component-bindgen" }
 structopt = "0.3.26"
-wasm-encoder = "0.209.1"
-wasm-metadata = "0.209.1"
-wasmparser = "0.209.1"
-wasmprinter = "0.209.1"
+wasm-encoder = "0.212.0"
+wasm-metadata = "0.212.0"
+wasmparser = "0.212.0"
+wasmprinter = "0.212.0"
 #wasmtime-environ = { version = "22.0.0", features = ["component-model", "compile"] }
 wasmtime-environ = { git ="https://github.com/bytecodealliance/wasmtime", rev = "9bdb731ab653a3845a1fa6cb6fcb20505c049ee8", features = ["component-model", "compile"] }
-wat = "1.209.1"
-wit-bindgen = "0.26.0"
-wit-bindgen-core = "0.26.0"
-wit-component = { version = "0.209.1", features = ["dummy-module"] }
-wit-parser = "0.209.1"
+wat = "1.212.0"
+wit-bindgen = "0.27.0"
+wit-bindgen-core = "0.27.0"
+wit-component = { version = "0.212.0", features = ["dummy-module"] }
+wit-parser = "0.212.0"
 xshell = "0.2.6"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,11 @@ wat = "1.212.0"
 wit-bindgen = "0.27.0"
 wit-bindgen-core = "0.27.0"
 wit-component = { version = "0.212.0", features = ["dummy-module"] }
-wit-parser = "0.212.0"
+#wit-parser = "0.212.0"
+# NOTE: we can't use the version of wasm-tools below *just* yet, because it 
+# uses an unreleased version of wit-parser (the only errors left are wit_parser::resolve::Resolve 
+# version inconsistencies
+wit-parser = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "10d2e21b2171cf2a2227f9de04ac89985042a5f0" }
 xshell = "0.2.6"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ wasm-encoder = "0.209.1"
 wasm-metadata = "0.209.1"
 wasmparser = "0.209.1"
 wasmprinter = "0.209.1"
-wasmtime-environ = { version = "22.0.0", features = ["component-model", "compile"] }
+#wasmtime-environ = { version = "22.0.0", features = ["component-model", "compile"] }
+wasmtime-environ = { git ="https://github.com/bytecodealliance/wasmtime", rev = "9bdb731ab653a3845a1fa6cb6fcb20505c049ee8", features = ["component-model", "compile"] }
 wat = "1.209.1"
 wit-bindgen = "0.26.0"
 wit-bindgen-core = "0.26.0"

--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use js_component_bindgen::{
     generate_types,
-    source::wit_parser::{Resolve, UnresolvedPackage},
+    source::wit_parser::{PackageId, Resolve, UnresolvedPackageGroup},
     transpile,
 };
 
@@ -117,16 +117,27 @@ impl Guest for JsComponentBindgenComponent {
         opts: TypeGenerationOptions,
     ) -> Result<Vec<(String, Vec<u8>)>, String> {
         let mut resolve = Resolve::default();
-        let id = match opts.wit {
+        let mut pkgs = Vec::<PackageId>::new();
+        match opts.wit {
             Wit::Source(source) => {
-                let pkg = UnresolvedPackage::parse(&PathBuf::from(format!("{name}.wit")), &source)
+                let UnresolvedPackageGroup {
+                    packages,
+                    source_map,
+                } = UnresolvedPackageGroup::parse(&PathBuf::from(format!("{name}.wit")), &source)
                     .map_err(|e| e.to_string())?;
-                resolve.push(pkg).map_err(|e| e.to_string())?
+
+                for unresolved_pkg in packages {
+                    pkgs.push(
+                        resolve
+                            .push(unresolved_pkg, &source_map)
+                            .map_err(|e| e.to_string())?,
+                    );
+                }
             }
             Wit::Path(path) => {
                 let path = PathBuf::from(path);
                 if path.is_dir() {
-                    resolve.push_dir(&path).map_err(|e| e.to_string())?.0
+                    pkgs = resolve.push_dir(&path).map_err(|e| e.to_string())?.0;
                 } else {
                     let contents = std::fs::read(&path)
                         .with_context(|| format!("failed to read file {path:?}"))
@@ -135,8 +146,17 @@ impl Guest for JsComponentBindgenComponent {
                         Ok(s) => s,
                         Err(_) => return Err("input file is not valid utf-8".into()),
                     };
-                    let pkg = UnresolvedPackage::parse(&path, text).map_err(|e| e.to_string())?;
-                    resolve.push(pkg).map_err(|e| e.to_string())?
+                    let UnresolvedPackageGroup {
+                        packages,
+                        source_map,
+                    } = UnresolvedPackageGroup::parse(&path, text).map_err(|e| e.to_string())?;
+                    for unresolved_pkg in packages {
+                        pkgs.push(
+                            resolve
+                                .push(unresolved_pkg, &source_map)
+                                .map_err(|e| e.to_string())?,
+                        );
+                    }
                 }
             }
             Wit::Binary(_) => todo!(),
@@ -144,7 +164,7 @@ impl Guest for JsComponentBindgenComponent {
 
         let world_string = opts.world.map(|world| world.to_string());
         let world = resolve
-            .select_world(id, world_string.as_deref())
+            .select_world(&pkgs, world_string.as_deref())
             .map_err(|e| e.to_string())?;
 
         let opts = js_component_bindgen::TranspileOpts {

--- a/crates/js-component-bindgen/Cargo.toml
+++ b/crates/js-component-bindgen/Cargo.toml
@@ -22,11 +22,11 @@ transpile-bindgen = []
 
 [dependencies]
 anyhow = { workspace = true }
+base64 = { workspace = true }
 heck = { workspace = true }
 wasmparser = { workspace = true }
+wasm-encoder = { workspace = true }
 wasmtime-environ = { workspace = true, features = ['component-model'] }
 wit-bindgen-core = { workspace = true }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }
-base64 = { workspace = true }
-wasm-encoder = { workspace = true }

--- a/crates/js-component-bindgen/Cargo.toml
+++ b/crates/js-component-bindgen/Cargo.toml
@@ -29,4 +29,3 @@ wasm-encoder = { workspace = true }
 wasmtime-environ = { workspace = true, features = ['component-model'] }
 wit-bindgen-core = { workspace = true }
 wit-component = { workspace = true }
-wit-parser = { workspace = true }

--- a/crates/js-component-bindgen/src/core.rs
+++ b/crates/js-component-bindgen/src/core.rs
@@ -39,7 +39,6 @@
 use anyhow::{bail, Result};
 use std::collections::{HashMap, HashSet};
 use wasm_encoder::*;
-use wasmparser::collections::IndexMap;
 use wasmparser::*;
 use wasmtime_environ::component::CoreDef;
 use wasmtime_environ::{wasmparser, ModuleTranslation};
@@ -91,8 +90,7 @@ impl<'a> Translation<'a> {
         let mut features = WasmFeatures::default();
         features.set(WasmFeatures::MULTI_MEMORY, false);
         match Validator::new_with_features(features).validate_all(translation.wasm) {
-            // This module validates without multi-memory, no need to augment
-            // it
+            // This module validates without multi-memory, no need to augment it
             Ok(_) => return Ok(Translation::Normal(translation)),
             Err(e) => {
                 features.set(WasmFeatures::MULTI_MEMORY, true);
@@ -190,7 +188,7 @@ impl<'a> Translation<'a> {
 
     /// Returns the exports of this module, which are not modified by
     /// augmentation.
-    pub fn exports(&self) -> &IndexMap<String, EntityIndex> {
+    pub fn exports(&self) -> &wasmparser::collections::IndexMap<String, EntityIndex> {
         match self {
             Translation::Normal(translation) => &translation.module.exports,
             Translation::Augmented { original, .. } => &original.module.exports,

--- a/crates/js-component-bindgen/src/core.rs
+++ b/crates/js-component-bindgen/src/core.rs
@@ -702,10 +702,10 @@ macro_rules! define_translate {
     });
     (mk CallIndirect $ty:ident $table:ident $table_byte:ident) => ({
         let _ = $table_byte;
-        CallIndirect { ty: $ty, table: $table }
+        CallIndirect { type_index: $ty, table_index: $table }
     });
     (mk ReturnCallIndirect $ty:ident $table:ident) => (
-        ReturnCallIndirect { ty: $ty, table: $table }
+        ReturnCallIndirect { type_index: $ty, table_index: $table }
     );
     (mk I32Const $v:ident) => (I32Const($v));
     (mk I64Const $v:ident) => (I64Const($v));

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -6,8 +6,9 @@ use heck::*;
 use wasmtime_environ::component::{ResourceIndex, TypeResourceTableIndex};
 use wit_bindgen_core::abi::{Bindgen, Bitcast, Instruction};
 use wit_component::StringEncoding;
-use wit_parser::abi::WasmType;
-use wit_parser::*;
+
+use wit_bindgen_core::wit_parser::abi::WasmType;
+use wit_bindgen_core::wit_parser::{Handle, Resolve, SizeAlign, Type, TypeDefKind, TypeId};
 
 use crate::intrinsics::Intrinsic;
 use crate::source;

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1,15 +1,17 @@
-use crate::intrinsics::Intrinsic;
-use crate::source;
-use crate::{uwrite, uwriteln};
-use heck::*;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::mem;
+
+use heck::*;
 use wasmtime_environ::component::{ResourceIndex, TypeResourceTableIndex};
 use wit_bindgen_core::abi::{Bindgen, Bitcast, Instruction};
 use wit_component::StringEncoding;
 use wit_parser::abi::WasmType;
 use wit_parser::*;
+
+use crate::intrinsics::Intrinsic;
+use crate::source;
+use crate::{uwrite, uwriteln};
 
 #[derive(PartialEq)]
 pub enum ErrHandling {

--- a/crates/js-component-bindgen/src/lib.rs
+++ b/crates/js-component-bindgen/src/lib.rs
@@ -1,27 +1,27 @@
-mod core;
-mod files;
-mod transpile_bindgen;
-mod ts_bindgen;
-
-pub mod esm_bindgen;
-pub mod function_bindgen;
-pub mod intrinsics;
-pub mod names;
-pub mod source;
-pub use transpile_bindgen::{BindingsMode, InstantiationMode, TranspileOpts};
-
-use anyhow::Result;
-use transpile_bindgen::transpile_bindgen;
-
-use anyhow::{bail, Context};
+use anyhow::{bail, Context, Result};
 use wasmtime_environ::component::Export;
 use wasmtime_environ::component::{ComponentTypesBuilder, StaticModuleIndex};
 use wasmtime_environ::wasmparser::Validator;
 use wasmtime_environ::{PrimaryMap, ScopeVec, Tunables};
 use wit_component::DecodedWasm;
 
+mod core;
+mod files;
+
+pub mod esm_bindgen;
+pub mod function_bindgen;
+pub mod intrinsics;
+pub mod names;
+pub mod source;
+
+mod transpile_bindgen;
+use transpile_bindgen::transpile_bindgen;
+pub use transpile_bindgen::{BindingsMode, InstantiationMode, TranspileOpts};
+
+mod ts_bindgen;
 use ts_bindgen::ts_bindgen;
-use wit_parser::{Resolve, Type, TypeDefKind, TypeId, WorldId};
+
+use wit_bindgen_core::wit_parser::{Resolve, Type, TypeDefKind, TypeId, WorldId};
 
 /// Calls [`write!`] with the passed arguments and unwraps the result.
 ///
@@ -96,7 +96,7 @@ pub fn transpile(component: &[u8], opts: TranspileOpts) -> Result<Transpiled, an
         .context("failed to extract interface information from component")?;
 
     let (resolve, world_id) = match decoded {
-        DecodedWasm::WitPackage(..) => bail!("unexpected wit package as input"),
+        DecodedWasm::WitPackages(..) => bail!("unexpected wit package as input"),
         DecodedWasm::Component(resolve, world_id) => (resolve, world_id),
     };
 

--- a/crates/js-component-bindgen/src/lib.rs
+++ b/crates/js-component-bindgen/src/lib.rs
@@ -128,7 +128,7 @@ pub fn transpile(component: &[u8], opts: TranspileOpts) -> Result<Transpiled, an
         .map(|(_i, module)| core::Translation::new(module, opts.multi_memory))
         .collect::<Result<_>>()?;
 
-    let types = types.finish(&PrimaryMap::new(), Vec::new(), Vec::new());
+    let types = types.finish(&wasmtime_environ::component::Component::default());
 
     // Insert all core wasm modules into the generated `Files` which will
     // end up getting used in the `generate_instantiate` method.

--- a/crates/js-component-bindgen/src/source.rs
+++ b/crates/js-component-bindgen/src/source.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Write};
 use std::ops::Deref;
 
-pub use wit_parser;
+pub use wit_bindgen_core::wit_parser;
 
 #[derive(Default)]
 pub struct Source {

--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -8,7 +8,11 @@ use heck::*;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write;
-use wit_parser::*;
+
+use wit_bindgen_core::wit_parser::{
+    Docs, Enum, Flags, Function, FunctionKind, Handle, InterfaceId, Record, Resolve, Result_,
+    Tuple, Type, TypeDefKind, TypeId, TypeOwner, Variant, WorldId, WorldItem, WorldKey,
+};
 
 struct TsBindgen {
     /// The source code for the "main" file that's going to be created for the
@@ -70,7 +74,7 @@ pub fn ts_bindgen(
                 WorldItem::Interface { id, stability: _ } => match name {
                     WorldKey::Name(name) => {
                         // kebab name -> direct ns namespace import
-                        bindgen.import_interface(resolve, name, *id, files);
+                        bindgen.import_interface(resolve, &name, *id, files);
                     }
                     // namespaced ns:pkg/iface
                     // TODO: map support

--- a/crates/wasm-tools-component/src/lib.rs
+++ b/crates/wasm-tools-component/src/lib.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use wasm_encoder::{Encode, Section};
 use wasm_metadata::Producers;
 use wit_component::{ComponentEncoder, DecodedWasm, WitPrinter};
-use wit_parser::{Resolve, UnresolvedPackage};
+use wit_parser::{PackageId, Resolve, UnresolvedPackageGroup};
 
 use exports::local::wasm_tools::tools::{
     EmbedOpts, Guest, ModuleMetaType, ModuleMetadata, ProducersFields, StringEncoding,
@@ -58,12 +58,12 @@ impl Guest for WasmToolsJs {
         // let world = decode_world("component", &binary);
 
         let doc = match &decoded {
-            DecodedWasm::WitPackage(_resolve, _pkg) => panic!("Unexpected wit package"),
+            DecodedWasm::WitPackages(_resolve, _pkg) => panic!("Unexpected wit package"),
             DecodedWasm::Component(resolve, world) => resolve.worlds[*world].package.unwrap(),
         };
 
         let output = WitPrinter::default()
-            .print(decoded.resolve(), doc)
+            .print(decoded.resolve(), &[doc])
             .map_err(|e| format!("Unable to print wit\n${:?}", e))?;
 
         Ok(output)
@@ -73,24 +73,42 @@ impl Guest for WasmToolsJs {
         let binary = &embed_opts.binary;
 
         let mut resolve = Resolve::default();
-
-        let id = if let Some(wit_source) = &embed_opts.wit_source {
+        let mut package_ids = Vec::<PackageId>::new();
+        if let Some(wit_source) = &embed_opts.wit_source {
             let path = PathBuf::from("component.wit");
-            let pkg = UnresolvedPackage::parse(&path, wit_source).map_err(|e| e.to_string())?;
-            resolve.push(pkg).map_err(|e| e.to_string())?
+            let UnresolvedPackageGroup {
+                packages,
+                source_map,
+            } = UnresolvedPackageGroup::parse(&path, wit_source).map_err(|e| e.to_string())?;
+            for unresolved_pkg in packages {
+                package_ids.push(
+                    resolve
+                        .push(unresolved_pkg, &source_map)
+                        .map_err(|e| e.to_string())?,
+                );
+            }
         } else {
             let wit_path = &PathBuf::from(embed_opts.wit_path.as_ref().unwrap());
             if metadata(wit_path).unwrap().is_file() {
-                let pkg = UnresolvedPackage::parse_file(wit_path).map_err(|e| e.to_string())?;
-                resolve.push(pkg).map_err(|e| e.to_string())?
+                let UnresolvedPackageGroup {
+                    packages,
+                    source_map,
+                } = UnresolvedPackageGroup::parse_file(wit_path).map_err(|e| e.to_string())?;
+                for unresolved_pkg in packages {
+                    package_ids.push(
+                        resolve
+                            .push(unresolved_pkg, &source_map)
+                            .map_err(|e| e.to_string())?,
+                    );
+                }
             } else {
-                resolve.push_dir(wit_path).map_err(|e| e.to_string())?.0
+                package_ids = resolve.push_dir(wit_path).map_err(|e| e.to_string())?.0;
             }
         };
 
         let world_string = embed_opts.world.as_ref().map(|world| world.to_string());
         let world = resolve
-            .select_world(id, world_string.as_deref())
+            .select_world(&package_ids, world_string.as_deref())
             .map_err(|e| e.to_string())?;
 
         let string_encoding = match &embed_opts.string_encoding {

--- a/crates/wasm-tools-component/src/lib.rs
+++ b/crates/wasm-tools-component/src/lib.rs
@@ -107,8 +107,20 @@ impl Guest for WasmToolsJs {
         };
 
         let world_string = embed_opts.world.as_ref().map(|world| world.to_string());
+
+        // We expect only one package to be present
+        let pkg_id = match package_ids[..] {
+            [pkg] => pkg,
+            _ => {
+                return Err(format!(
+                    "expected 1 package after resolving, found [{}]",
+                    package_ids.len()
+                ));
+            }
+        };
+
         let world = resolve
-            .select_world(&package_ids, world_string.as_deref())
+            .select_world(pkg_id, world_string.as_deref())
             .map_err(|e| e.to_string())?;
 
         let string_encoding = match &embed_opts.string_encoding {

--- a/test/cli.js
+++ b/test/cli.js
@@ -7,11 +7,13 @@ import {
   writeFile,
   mkdtemp,
 } from "node:fs/promises";
-import { fileURLToPath, pathToFileURL } from "url";
-import { exec, jcoPath } from "./helpers.js";
 import { tmpdir, EOL } from "node:os";
 import { resolve, normalize, sep } from "node:path";
 import { execArgv } from "node:process";
+
+import { fileURLToPath, pathToFileURL } from "url";
+
+import { exec, jcoPath, getTmpDir } from "./helpers.js";
 
 const multiMemory = execArgv.includes("--experimental-wasm-multi-memory")
   ? ["--multi-memory"]
@@ -19,15 +21,6 @@ const multiMemory = execArgv.includes("--experimental-wasm-multi-memory")
 
 export async function cliTest(fixtures) {
   suite("CLI", () => {
-    /**
-     * Securely creates a temporary directory and returns its path.
-     *
-     * The new directory is created using `fsPromises.mkdtemp()`.
-     */
-    async function getTmpDir() {
-      return await mkdtemp(normalize(tmpdir() + sep));
-    }
-
     var tmpDir;
     var outDir;
     var outFile;

--- a/test/fixtures/componentize/feature-gates/source.js
+++ b/test/fixtures/componentize/feature-gates/source.js
@@ -1,0 +1,16 @@
+// NOTE: This expects to implement the 'imported' world of `feature-gates.wit`
+export const foo = {
+  // A should be present
+  a() {
+    println("OK");
+  },
+
+  // B should be present since 
+  b() {
+    println("OK");
+  }
+
+  // NOTE: c() should not be required/present at all
+
+  // TODO: test interaction with features
+};

--- a/test/fixtures/wit/feature-gates.wit
+++ b/test/fixtures/wit/feature-gates.wit
@@ -1,0 +1,28 @@
+/// This WIT is used to test/ensure that JCO does not
+/// generate exports/imports for interfaces that are invalid 
+/// on the feature-gating feature of WIT
+///
+/// see: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#feature-gates
+
+package test:jco-feature-gates@0.2.1;
+
+interface foo {
+  a: func();
+
+  @since(version = 0.2.1)
+  b: func();
+
+  @since(version = 0.2.2)
+  c: func();
+
+  // @unstable(feature = fancier-foo)
+  // d: func();
+}
+
+world imported {
+  imported foo;
+}
+
+world exported {
+  export foo;
+}

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,8 @@
+import { tmpdir } from "node:os";
 import { spawn } from "node:child_process";
 import { argv, execArgv } from "node:process";
+import { normalize, sep } from "node:path";
+import { mkdtemp } from "node:fs/promises";
 
 export const jcoPath = "src/jco.js";
 const multiMemory =
@@ -26,4 +29,13 @@ export async function exec(cmd, ...args) {
     );
   });
   return { stdout, stderr };
+}
+
+/**
+ * Securely creates a temporary directory and returns its path.
+ *
+ * The new directory is created using `fsPromises.mkdtemp()`.
+ */
+export async function getTmpDir() {
+  return await mkdtemp(normalize(tmpdir() + sep));
 }

--- a/test/preview2.js
+++ b/test/preview2.js
@@ -3,22 +3,15 @@ import { readFile, rm, writeFile, mkdtemp } from "node:fs/promises";
 import { createServer } from "node:http";
 import { tmpdir } from "node:os";
 import { normalize, resolve, sep } from "node:path";
+
 import { fileURLToPath, pathToFileURL } from "url";
-import { componentNew, preview1AdapterCommandPath } from "../src/api.js";
-import { exec, jcoPath } from "./helpers.js";
 import { HTTPServer } from "@bytecodealliance/preview2-shim/http";
+
+import { componentNew, preview1AdapterCommandPath } from "../src/api.js";
+import { exec, jcoPath, getTmpDir } from "./helpers.js";
 
 export async function preview2Test() {
   suite("Preview 2", () => {
-    /**
-     * Securely creates a temporary directory and returns its path.
-     *
-     * The new directory is created using `fsPromises.mkdtemp()`.
-     */
-    async function getTmpDir() {
-      return await mkdtemp(normalize(tmpdir() + sep));
-    }
-
     var tmpDir;
     var outFile;
     suiteSetup(async function () {

--- a/test/test.js
+++ b/test/test.js
@@ -29,11 +29,11 @@ import { preview2Test } from './preview2.js';
 import { witTest } from './wit.js';
 import { tsTest } from './typescript.js';
 
-await codegenTest(componentFixtures);
-tsTest();
-await preview2Test();
-await runtimeTest(componentFixtures);
-await commandsTest();
-await apiTest(componentFixtures);
-await cliTest(componentFixtures);
+// await codegenTest(componentFixtures);
+// tsTest();
+// await preview2Test();
+// await runtimeTest(componentFixtures);
+// await commandsTest();
+// await apiTest(componentFixtures);
+// await cliTest(componentFixtures);
 await witTest();

--- a/test/test.js
+++ b/test/test.js
@@ -15,6 +15,7 @@
 import { env } from 'node:process';
 import { readdir } from 'node:fs/promises';
 
+// List of all component fixtures
 const componentFixtures = env.COMPONENT_FIXTURES
   ? env.COMPONENT_FIXTURES.split(',')
   : (await readdir('test/fixtures/components')).filter(name => name !== 'dummy_reactor.component.wasm');
@@ -25,6 +26,7 @@ import { commandsTest } from './commands.js';
 import { apiTest } from './api.js';
 import { cliTest } from './cli.js';
 import { preview2Test } from './preview2.js';
+import { witTest } from './wit.js';
 import { tsTest } from './typescript.js';
 
 await codegenTest(componentFixtures);
@@ -34,3 +36,4 @@ await runtimeTest(componentFixtures);
 await commandsTest();
 await apiTest(componentFixtures);
 await cliTest(componentFixtures);
+await witTest();

--- a/test/wit.js
+++ b/test/wit.js
@@ -1,0 +1,82 @@
+import { strictEqual } from "node:assert";
+import { readFile, rm, writeFile, mkdtemp } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { normalize, resolve, sep } from "node:path";
+
+import { fileURLToPath, pathToFileURL } from "url";
+import { HTTPServer } from "@bytecodealliance/preview2-shim/http";
+
+import { componentNew, preview1AdapterCommandPath } from "../src/api.js";
+import { exec, jcoPath, getTmpDir } from "./helpers.js";
+
+export async function witTest() {
+  suite("WIT", () => {
+    var tmpDir;
+    var outFile;
+
+    suiteSetup(async function () {
+      tmpDir = await getTmpDir();
+      outFile = resolve(tmpDir, "out-component-file");
+    });
+
+    suiteTeardown(async function () {
+      try {
+        await rm(tmpDir, { recursive: true });
+      } catch {}
+    });
+
+    teardown(async function () {
+      try {
+        await rm(outFile);
+      } catch {}
+    });
+
+    /** 
+     * Ensure feature gates work properly
+     * 
+     * see: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#feature-gates
+     */
+    test("feature-gates", async () => {
+      const runtimeName = "semver";
+
+      const { stderr } = await exec(
+        jcoPath,
+        "componentize",
+        "test/fixtures/componentize/feature-gates/source.js",
+        "-w",
+        "test/fixtures/wit",
+        "--world-name",
+        "test:jco-feature-gates/imported",
+        "-o",
+        outFile
+      );
+      strictEqual(stderr, "");
+
+      // TODO: check the generated code to ensure that
+      // no featuregate related functions are present
+
+      const outDir = fileURLToPath(
+        new URL(`./output/${runtimeName}`, import.meta.url)
+      );
+
+      {
+        const { stderr } = await exec(
+          jcoPath,
+          "transpile",
+          outFile,
+          "--name",
+          runtimeName,
+          "-o",
+          outDir
+        );
+        strictEqual(stderr, "");
+      }
+
+      console.log(`OUTPUT to [test/output/${runtimeName}.js]`);
+
+      // TODO(remove): probably don't need to execute it!
+      // await exec(`test/output/${runtimeName}.js`);
+    });
+  });
+}

--- a/xtask/src/generate/wasi_types.rs
+++ b/xtask/src/generate/wasi_types.rs
@@ -23,7 +23,7 @@ pub(crate) fn run() -> Result<()> {
             .unwrap()
             .1;
 
-        let world = resolve.select_world(preview2, Some(world_name))?;
+        let world = resolve.select_world(&[preview2], Some(world_name))?;
 
         let opts = js_component_bindgen::TranspileOpts {
             name: "component".to_string(),


### PR DESCRIPTION
## :warning: DO NOT MERGE

Still a couple issues left: 

- `define_translate` macro broken
- `Instruction` vs `Operation` use in `wasmparser::for_each_operator!`


```rust
   Compiling js-component-bindgen v1.2.4 (/home/user/code/work/cosmonic/forks/jco/crates/js-component-bindgen)
error: no rules expected the token `ordering`
   --> crates/js-component-bindgen/src/core.rs:690:57
    |
614 | macro_rules! define_translate {
    | ----------------------------- when calling this macro
...
688 |     (translate $self:ident $op:ident $($arg:ident)*) => {{
    |                                        ----------
689 |         $(
690 |             let $arg = define_translate!(map $self $arg $arg);
    |                                                         ^^^^ no rules expected this token in macro call
...
776 |     wasmparser::for_each_operator!(define_translate);
    |     ------------------------------------------------ in this macro invocation
    |
note: while trying to match `memarg`
   --> crates/js-component-bindgen/src/core.rs:732:33
    |
732 |     (map $self:ident $arg:ident memarg) => {$self.memarg($arg)};
    |                                 ^^^^^^
    = note: captured metavariables except for `:tt`, `:ident` and `:lifetime` cannot be compared to other tokens
    = note: see <https://doc.rust-lang.org/nightly/reference/macros-by-example.html#forwarding-a-matched-fragment> for more information
    = help: try using `:tt` instead in the macro definition
    = note: this error originates in the macro `define_translate` which comes from the expansion of the macro `wasmparser::for_each_operator` (in Nightly builds, run with -Z macro-backtrace for more info)

error[E0308]: mismatched types
   --> crates/js-component-bindgen/src/core.rs:693:32
    |
693 |         $self.func.instruction(&insn);
    |                    ----------- ^^^^^ expected `&Instruction<'_>`, found `&Operator<'_>`
    |                    |
    |                    arguments to this method are incorrect
...
776 |     wasmparser::for_each_operator!(define_translate);
    |     ------------------------------------------------ in this macro invocation
    |
    = note: expected reference `&wasm_encoder::Instruction<'_>`
               found reference `&wasmtime_environ::wasmparser::Operator<'_>`
note: method defined here
   --> /home/user/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-encoder-0.202.0/src/core/code.rs:216:12
    |
216 |     pub fn instruction(&mut self, instruction: &Instruction) -> &mut Self {
    |            ^^^^^^^^^^^
    = note: this error originates in the macro `define_translate` which comes from the expansion of the macro `wasmparser::for_each_operator` (in Nightly builds, run with -Z macro-backtrace for more info)

For more information about this error, try `rustc --explain E0308`.
error: could not compile `js-component-bindgen` (lib) due to 18 previous errors
```