### PR TITLE
release: js-component-bindgen v1.19.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,7 +836,7 @@ dependencies = [
 
 [[package]]
 name = "js-component-bindgen"
-version = "1.19.0-rc.0"
+version = "1.19.0-rc.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,4 +57,4 @@ wit-bindgen-core = { version = "0.54.0", default-features = false }
 wit-component = { version = "0.245.1", features = ["dummy-module"] }
 wit-parser = { version = "0.245.1", default-features = false }
 
-js-component-bindgen = { version = "1.19.0-rc.0", path = "./crates/js-component-bindgen" }
+js-component-bindgen = { version = "1.19.0-rc.1", path = "./crates/js-component-bindgen" }

--- a/crates/js-component-bindgen/CHANGELOG.md
+++ b/crates/js-component-bindgen/CHANGELOG.md
@@ -1,5 +1,416 @@
 # Changelog
 
+## [1.19.0-rc.1] - 2026-05-13
+
+### 🚀 Features
+
+- _(bindgen)_ add support for stream reads with count > 1 by @andreiltd
+
+- _(bindgen)_ implement future<future<t>> lower by @vados-cosmonic
+
+- _(bindgen)_ fill out future lower impl by @vados-cosmonic
+
+- _(bindgen)_ add --strict option for enabling type checks by @vados-cosmonic
+
+- _(bindgen)_ add support for p3 futures by @vados-cosmonic
+
+- _(bindgen)_ add explicit checks for lowered numeric primitives by @vados-cosmonic
+
+- _(bindgen)_ host side stream writes from any async iterator by @vados-cosmonic
+
+- _(bindgen)_ implement Instruction::StreamLower by @vados-cosmonic
+
+- _(bindgen)_ configure wasmparser for wasm 3.0 support by @vados-cosmonic
+
+- _(bindgen)_ add drop for external stream class by @vados-cosmonic
+
+- _(bindgen)_ add stream lift for flags by @vados-cosmonic
+
+- _(bindgen)_ add flat lift for tuple<t> by @vados-cosmonic
+
+- _(bindgen)_ implement fixed length lists by @yannbolliger
+
+- _(bindgen)_ add stubs for {Enter,Exit}SyncCall by @vados-cosmonic
+
+- _(bindgen)_ add basic avoidance of overlapping async task runs by @vados-cosmonic
+
+- _(bindgen)_ add p3 stream implementation by @vados-cosmonic
+
+- _(bindgen)_ add semver-compatible matching by @ricochet
+
+- _(bindgen)_ add "use jco" telemetry directive by @vados-cosmonic
+
+- _(bindgen)_ add a check for multiple tasks for a wasm export by @vados-cosmonic
+
+- _(bindgen)_ lower impl for results/variants, error context by @vados-cosmonic
+
+- _(bindgen)_ add machinery for lowering guest->guest async results by @vados-cosmonic
+
+- _(bindgen)_ require lifted exports to be async lowered by @vados-cosmonic
+
+- _(bindgen)_ wrap detected lowers for host fns by @vados-cosmonic
+
+- _(bindgen)_ record call metadata with subtasks by @vados-cosmonic
+
+- _(bindgen)_ support recording memories for components by @vados-cosmonic
+
+- _(bindgen)_ introduce global per-component async lower lookup by @vados-cosmonic
+
+- _(bindgen)_ async lowering logic for host imports by @vados-cosmonic
+
+- _(bindgen)_ add trampoline for lower import by @vados-cosmonic
+
+- _(bindgen)_ generate subtasks for async host imports by @vados-cosmonic
+
+- _(bindgen)_ distinguish host provided imports by @vados-cosmonic
+
+- _(bindgen)_ implement gc valtype conversion by @vados-cosmonic
+
+- _(bindgen)_ return promises for sync lowered async functions by @vados-cosmonic
+
+- _(bindgen)_ generate Disposable interface for wasm resources (#901) by @iamrajiv
+
+- _(bindgen)_ support futures and streams (#806) by @vados-cosmonic
+
+- _(bindgen)_ implement waitable set intrinsics (#767) by @vados-cosmonic
+
+- _(bindgen)_ implement yield (#745) by @vados-cosmonic
+
+- _(bindgen)_ implement task.cancel (#743) by @vados-cosmonic
+
+- _(bindgen)_ implement backpressure.set (#742) by @vados-cosmonic
+
+- _(bindgen)_ context.{get|set}, initial task.return impl (#736) by @vados-cosmonic
+
+
+### 🐛 Bug Fixes
+
+- _(bindgen)_ register p3 global table-map intrinsics before per-table assignments by @GamePad64
+
+- _(bindgen)_ fix result rejection lowering and stream drop propagation by @andreiltd
+
+- _(bindgen)_ allow external crates to use intrinsic renderer by @vados-cosmonic
+
+- _(bindgen)_ ensure moving storage pointers by abi size by @andreiltd
+
+- _(bindgen)_ cache the listValue implementation by @andreiltd
+
+- _(bindgen)_ lift numeric p3 lists and streams as typed arrays by @andreiltd
+
+- _(bindgen)_ populate imported resource lower metadata by @andreiltd
+
+- _(bindgen)_ use async ABI for async imports by @andreiltd
+
+- _(bindgen)_ address code review by @andreiltd
+
+- _(bindgen)_ get blocked copy result from pending event by @andreiltd
+
+- _(bindgen)_ avoid async future and stream host injection deadlocks by @andreiltd
+
+- _(bindgen)_ return state-only handle when async-lowered import resolves eagerly by @andreiltd
+
+- _(bindgen)_ use waitable index in p3 future event payload by @andreiltd
+
+- _(bindgen)_ lint & nested future check by @vados-cosmonic
+
+- _(bindgen)_ progress towards nested futture read by @vados-cosmonic
+
+- _(bindgen)_ fix task.return param spill check by @vados-cosmonic
+
+- _(bindgen)_ more direct task failure by @vados-cosmonic
+
+- _(bindgen)_ fix error passing for initial export call errors by @vados-cosmonic
+
+- _(bindgen)_ re-enable determinism coinflip by @vados-cosmonic
+
+- _(bindgen)_ remove leftover debug code by @vados-cosmonic
+
+- _(bindgen)_ use IndexMap for deterministic export iteration order by @wondenge
+
+- _(bindgen)_ resource hookup for imports by @vados-cosmonic
+
+- _(bindgen)_ use adhoc mapping while generating lift/lower fns by @vados-cosmonic
+
+- _(bindgen)_ impl async stream lower owned resources by @vados-cosmonic
+
+- _(bindgen)_ implementation of flat lower own by @vados-cosmonic
+
+- _(bindgen)_ fix async future JS codegen producing invalid output by @wondenge
+
+- _(bindgen)_ async stream list lower impl by @vados-cosmonic
+
+- _(bindgen)_ option, result, flag lowers by @vados-cosmonic
+
+- _(bindgen)_ async stream option & result lowering by @vados-cosmonic
+
+- _(bindgen)_ revert utf16 encoding changes by @vados-cosmonic
+
+- _(bindgen)_ utf16 decode logic by @vados-cosmonic
+
+- _(bindgen)_ fill in missing lower impls by @vados-cosmonic
+
+- _(bindgen)_ async stream record lowering impl by @vados-cosmonic
+
+- _(bindgen)_ async string flat lowering missing realloc by @vados-cosmonic
+
+- _(bindgen)_ missing ctx in memory usage by @vados-cosmonic
+
+- _(bindgen)_ host-side write post-read event clearing by @vados-cosmonic
+
+- _(bindgen)_ fix Instruction::StreamLift in async contexts by @vados-cosmonic
+
+- _(bindgen)_ done check during read by @vados-cosmonic
+
+- _(bindgen)_ check for host data in host-controlled streams by @vados-cosmonic
+
+- _(bindgen)_ stream drop logic by @vados-cosmonic
+
+- _(bindgen)_ generate ancillary type generation for functions by @vados-cosmonic
+
+- _(bindgen)_ bindgen runtime bugs by @vados-cosmonic
+
+- _(bindgen)_ flat stream lift for nested streams by @vados-cosmonic
+
+- _(bindgen)_ allow for imported resources to be lifted out by @vados-cosmonic
+
+- _(bindgen)_ more gracefully handle missing type data by @vados-cosmonic
+
+- _(bindgen)_ add remaining stream lift tests by @vados-cosmonic
+
+- _(bindgen)_ regression in support for core wasm export initialize by @vados-cosmonic
+
+- _(bindgen)_ stream timing issue by @vados-cosmonic
+
+- _(bindgen)_ list canon lower for special cased list<u8> by @vados-cosmonic
+
+- _(bindgen)_ use of async enter by @vados-cosmonic
+
+- _(bindgen)_ error tag name by @vados-cosmonic
+
+- _(bindgen)_ async flat lift impl for fixed length lists by @vados-cosmonic
+
+- _(bindgen)_ list async lift impls for list & fixed size list by @vados-cosmonic
+
+- _(bindgen)_ make all bindings const by @yannbolliger
+
+- _(bindgen)_ variant lifting impl, update code for lowering by @vados-cosmonic
+
+- _(bindgen)_ record lift implementation by @vados-cosmonic
+
+- _(bindgen)_ flat string lift by @vados-cosmonic
+
+- _(bindgen)_ allow overriding lower import trampolines for deno by @vados-cosmonic
+
+- _(bindgen)_ err ctx impl by @vados-cosmonic
+
+- _(bindgen)_ stream impl, determinism, async machinery by @vados-cosmonic
+
+- _(bindgen)_ wait for exits rather than result returns by @vados-cosmonic
+
+- _(bindgen)_ avoid component invariant checking for host tasks by @vados-cosmonic
+
+- _(bindgen)_ remove lift/lower duplication on task.resolve by @vados-cosmonic
+
+- _(bindgen)_ stream end handling, event loop by @vados-cosmonic
+
+- _(bindgen)_ enable wasm exceptions proposal support by @rioam2
+
+- _(bindgen)_ missing scope_id for resource borrow by @vados-cosmonic
+
+- _(bindgen)_ async host import lookup by @vados-cosmonic
+
+- _(bindgen)_ resource connecting, comments around lifts for futures by @vados-cosmonic
+
+- _(bindgen)_ resource tracking by @vados-cosmonic
+
+- _(bindgen)_ typo in lift code by @vados-cosmonic
+
+- _(bindgen)_ unit stream copy check by @vados-cosmonic
+
+- _(bindgen)_ refactor canon list lower handling by @vados-cosmonic
+
+- _(bindgen)_ s32 flat lower by @vados-cosmonic
+
+- _(bindgen)_ remove extraneous subtask resolve by @vados-cosmonic
+
+- _(bindgen)_ params/result ptr separation, import key trimming by @vados-cosmonic
+
+- _(bindgen)_ waitable set poll functionality for latest p3 updates by @vados-cosmonic
+
+- _(bindgen)_ param checking logic, prepare call by @vados-cosmonic
+
+- _(bindgen)_ fix bugs in future/stream & waitable trampolines by @vados-cosmonic
+
+- _(bindgen)_ post-return test, loosen reqs for fused post-return by @vados-cosmonic
+
+- _(bindgen)_ lowers for top level (root) host imports by @vados-cosmonic
+
+- _(bindgen)_ disable useful error test, fix fn name parsing by @vados-cosmonic
+
+- _(bindgen)_ async host imports by @vados-cosmonic
+
+- _(bindgen)_ subtask return logic for fused components by @vados-cosmonic
+
+- _(bindgen)_ wire up fused lift lower by @vados-cosmonic
+
+- _(bindgen)_ interpolation on string length during encoding by @vados-cosmonic
+
+- _(bindgen)_ working basic async host imports by @vados-cosmonic
+
+- _(bindgen)_ lowering, refactor string intrinsics for clarity by @vados-cosmonic
+
+- _(bindgen)_ memory index usage by @vados-cosmonic
+
+- _(bindgen)_ update async task & host code by @vados-cosmonic
+
+- _(bindgen)_ pass in memory getter to lower import by @vados-cosmonic
+
+- _(bindgen)_ host import in subtask start logic by @vados-cosmonic
+
+- _(bindgen)_ backpressure functionality by @vados-cosmonic
+
+- _(bindgen)_ fix missing backpressure machinery by @vados-cosmonic
+
+- _(bindgen)_ webidl binding account for missing internal keys by @vados-cosmonic
+
+- _(bindgen)_ allow missing current task by @vados-cosmonic
+
+- _(bindgen)_ required intrisnics for err context by @vados-cosmonic
+
+- _(bindgen)_ host provided hint on constructors by @vados-cosmonic
+
+- _(bindgen)_ use of size param, increase code limit by @vados-cosmonic
+
+- _(bindgen)_ fix host async import calling by @vados-cosmonic
+
+- _(bindgen)_ workaround lint for unused variables in macros by @vados-cosmonic
+
+- _(bindgen)_ loosen checks for task completion, fix conflict by @vados-cosmonic
+
+- _(bindgen)_ fix post return lookup by @vados-cosmonic
+
+- _(bindgen)_ async impl for task state & subtask management by @vados-cosmonic
+
+- _(bindgen)_ use ponyfill for `Promise.withResolvers` by @wooorm-arcjet
+
+- _(bindgen)_ allow extended const wasm feature during parse by @vados-cosmonic
+
+- _(bindgen)_ async task return value by @vados-cosmonic
+
+- _(bindgen)_ assert for stack values during a return for async by @vados-cosmonic
+
+- _(bindgen)_ fix async return param logic by @vados-cosmonic
+
+- _(bindgen)_ declare within declare for reserved words by @vados-cosmonic
+
+- _(bindgen)_ dispose type generation by @vados-cosmonic
+
+- _(bindgen)_ small fixups to global task id tracking codegen by @vados-cosmonic
+
+
+### 🚜 Refactor
+
+- _(bindgen)_ move stream host injection readiness check by @andreiltd
+
+- _(bindgen)_ update 'use jco' directive to 'use components' by @vados-cosmonic
+
+- _(bindgen)_ use upstream indexmap dep by @vados-cosmonic
+
+- _(bindgen)_ factor out strewam write injection, use w/ lower by @vados-cosmonic
+
+- _(bindgen)_ resource lift handling by @vados-cosmonic
+
+- _(bindgen)_ move resouce scope tracking by @vados-cosmonic
+
+- _(bindgen)_ use older iteration pattern for node 18/20 by @vados-cosmonic
+
+- _(bindgen)_ rework lowering code by @vados-cosmonic
+
+- _(bindgen)_ late handling of string encoding by @vados-cosmonic
+
+- _(bindgen)_ impl for fixed/unknown length lists by @vados-cosmonic
+
+- _(bindgen)_ rework async lift for enums by @vados-cosmonic
+
+- _(bindgen)_ consistent use of promise with resolvers ponyfill by @vados-cosmonic
+
+- _(bindgen)_ remove AsyncTask#pollForEvent by @vados-cosmonic
+
+- _(bindgen)_ clean up some code by @vados-cosmonic
+
+- _(bindgen)_ rework memory idx setting for tasks by @vados-cosmonic
+
+- _(bindgen)_ followup for rename of task creation intrinsic by @vados-cosmonic
+
+- _(bindgen)_ rename task creation intrinsic by @vados-cosmonic
+
+- _(bindgen)_ more flexibility for missing memories by @vados-cosmonic
+
+- _(bindgen)_ rework async task/subtask resolution handling by @vados-cosmonic
+
+- _(bindgen)_ exclusive locking logic by @vados-cosmonic
+
+- _(bindgen)_ intrinsics (#811) by @vados-cosmonic
+
+
+### ⚙️ Miscellaneous Tasks
+
+- _(bindgen)_ update comment by @vados-cosmonic
+
+- _(bindgen)_ set errored on tasks that error early by @vados-cosmonic
+
+- _(bindgen)_ update wasm/wit deps to 0.245.1 by @vados-cosmonic
+
+- _(bindgen)_ fmt by @vados-cosmonic
+
+- _(bindgen)_ clippy by @vados-cosmonic
+
+- _(bindgen)_ clippy by @vados-cosmonic
+
+- _(bindgen)_ show value in debug msg for incorrect variant input by @vados-cosmonic
+
+- _(bindgen)_ remove leftover debug line by @vados-cosmonic
+
+- _(bindgen)_ add debugging to unexpected results branch by @vados-cosmonic
+
+- _(bindgen)_ update upstream deps by @vados-cosmonic
+
+- _(bindgen)_ remove extra tick by @vados-cosmonic
+
+- _(bindgen)_ fmt by @vados-cosmonic
+
+- _(bindgen)_ lint by @vados-cosmonic
+
+- _(bindgen)_ fix clippy by @vados-cosmonic
+
+- _(bindgen)_ cargo fmt by @vados-cosmonic
+
+- _(bindgen)_ wit-bindgen -> 0.52.0 by @vados-cosmonic
+
+- _(bindgen)_ add backpressure dec/inc to early trampolines by @vados-cosmonic
+
+- _(bindgen)_ rustfmt by @vados-cosmonic
+
+- _(bindgen)_ fix lint by @vados-cosmonic
+
+- _(bindgen)_ cleanup testing code by @vados-cosmonic
+
+- _(bindgen)_ prep for writing out results for async calls by @vados-cosmonic
+
+- _(bindgen)_ remove some overly verbose logging by @vados-cosmonic
+
+- _(bindgen)_ fix lint by @vados-cosmonic
+
+- _(bindgen)_ fix lint by @vados-cosmonic
+
+- _(bindgen)_ fix lint by @vados-cosmonic
+
+- _(bindgen)_ update upstream deps by @vados-cosmonic
+
+- _(bindgen)_ remove leftover debug logs by @vados-cosmonic
+
+- _(bindgen)_ decouple jco and component bindgen versioning (#635) by @vados-cosmonic
+
 ## [1.19.0-rc.0] - 2026-05-12
 
 ### 🚀 Features

--- a/crates/js-component-bindgen/Cargo.toml
+++ b/crates/js-component-bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "js-component-bindgen"
-version = "1.19.0-rc.0"
+version = "1.19.0-rc.1"
 license = "Apache-2.0 WITH LLVM-exception"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]


### PR DESCRIPTION
This is a release prep branch for `js-component-bindgen` release `v1.19.0-rc.1`.

To ensure this release is ready to be merged:
  - [x] Review updated CHANGELOG(s)

After this PR is merged tagging, artifact builds and releasing will run automatically.